### PR TITLE
Feature/bl 11943 standardise zip names

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NODE_ENV=development
 DYNAMO_URL=http://host.docker.internal:8000
-DYNAMO_REGION=eu-west-2
+DYNAMO_REGION=eu-west-1

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# mac files
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Serverless Node lambdas (PatchLambdaFunction and BulkUpdateFunction) for patchin
 1. `npm i`
 1. add environment variables to `.env`
 1. `npm run build:prod`
+1. to build with commit id
+1. `npm run build:prod -- --emv.commit=<commit-hash>`
 1.  Zip file can be found in `./dist/`
 
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint '*/**/*.ts' --quiet --fix",
     "test": "jest --coverage tests/unit",
-    "test:integration": "npm run build:db:test && DYNAMO_URL='http://localhost:8002' DYNAMO_REGION='eu-west-2' jest --coverage tests/integration && npm run destroy:db:test",
+    "test:integration": "npm run build:db:test && DYNAMO_URL='http://localhost:8002' DYNAMO_REGION='eu-west-1' jest --coverage tests/integration && npm run destroy:db:test",
     "build:db:test": "docker run --name hvt-dynamo-test-write-api -p 8002:8000 -d amazon/dynamodb-local",
     "destroy:db:test": "docker stop hvt-dynamo-test-write-api && docker rm hvt-dynamo-test-write-api",
     "build:dev": "webpack-cli --config webpack.development.js",

--- a/tests/unit/handler/bulk-update.test.ts
+++ b/tests/unit/handler/bulk-update.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../src/lib/config', () => ({
   getConfig: jest.fn().mockReturnValue({
     NODE_ENV: 'development',
     DYNAMO_URL: 'some-url',
-    DYNAMO_REGION: 'eu-west-2',
+    DYNAMO_REGION: 'eu-west-1',
   }),
 }));
 

--- a/tests/unit/handler/patch.test.ts
+++ b/tests/unit/handler/patch.test.ts
@@ -9,7 +9,7 @@ jest.mock('../../../src/lib/config', () => ({
   getConfig: jest.fn().mockReturnValue({
     NODE_ENV: 'development',
     DYNAMO_URL: 'some-url',
-    DYNAMO_REGION: 'eu-west-2',
+    DYNAMO_REGION: 'eu-west-1',
   }),
 }));
 

--- a/tests/unit/service/dynamodb.service.test.ts
+++ b/tests/unit/service/dynamodb.service.test.ts
@@ -7,7 +7,7 @@ jest.mock('../../../src/lib/config', () => ({
   getConfig: jest.fn().mockReturnValue({
     NODE_ENV: 'development',
     DYNAMO_URL: 'some-url',
-    DYNAMO_REGION: 'eu-west-2',
+    DYNAMO_REGION: 'eu-west-1',
   }),
 }));
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,10 +1,7 @@
 const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
 const AwsSamPlugin = require('aws-sam-webpack-plugin');
 
 const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false });
-const PATCH_LAMBDA_NAME = "BulkUpdateFunction"; 
-const BULK_UPDATE_LAMBDA_NAME = "PatchLambdaFunction";
 
 module.exports = {
   // Loads the entry object from the AWS::Serverless::Function resources in your
@@ -34,11 +31,5 @@ module.exports = {
   // Add the AWS SAM Webpack plugin
   plugins: [
     awsSamPlugin,
-    new CopyPlugin({
-      patterns: [
-        { from: './.env', to: `.aws-sam/build/${PATCH_LAMBDA_NAME}/` },
-        { from: './.env', to: `.aws-sam/build/${BULK_UPDATE_LAMBDA_NAME}/` },
-      ],
-    }),
   ]
 };

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,7 +1,18 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyPlugin = require('copy-webpack-plugin');
+const PATCH_LAMBDA_NAME = "BulkUpdateFunction";
+const BULK_UPDATE_LAMBDA_NAME = "PatchLambdaFunction";
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: './.env', to: `.aws-sam/build/${PATCH_LAMBDA_NAME}/` },
+        { from: './.env', to: `.aws-sam/build/${BULK_UPDATE_LAMBDA_NAME}/` },
+      ],
+    }),
+  ]
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -6,8 +6,10 @@ const branchName = require('current-git-branch');
 
 const PATCH_LAMBDA_NAME = "BulkUpdateFunction"; 
 const BULK_UPDATE_LAMBDA_NAME = "PatchLambdaFunction";
-const OUTPUT_FOLDER = './dist'
+const INPUT_FOLDER = `.aws-sam/build/`;
+const OUTPUT_FOLDER = './dist';
 const BUILD_VERSION = branchName().replace("/","-");
+const BUILD_NAME = `HVT-WRITE-API-${BUILD_VERSION}`;
 
 class BundlePlugin {
   constructor(params) {
@@ -17,9 +19,7 @@ class BundlePlugin {
 
   apply(compiler) {
     compiler.hooks.afterEmit.tap('zip-pack-plugin', async (compilation) => {
-      this.archives.forEach(async (archive) => {
-        await this.createArchive(archive.inputPath, archive.outputPath, archive.outputName, archive.ignore);
-      })
+      await this.createArchive(INPUT_FOLDER, OUTPUT_FOLDER, BUILD_NAME, 'template.yaml');
 
       this.assets.forEach((asset) => {
         fs.copySync(asset.inputPath, asset.outputPath);
@@ -41,13 +41,13 @@ class BundlePlugin {
     archive.on('error', function(err){
         throw err;
     });
-    
+
     archive.pipe(output);
     archive.glob(
       `**/*`, 
       { 
         cwd: inputPath,
-        skip: ignore
+        ignore: ignore
       }
     );
     return archive.finalize();


### PR DESCRIPTION
- Optionally pass in commit id when building so the zip file
is named correctly through build config files, not through
Jenkinsfile scripts
- Pipeline can now call build command:
`npm run build:prod -- --env.commit=<commit-hash>`
- Remove the .env file from prod builds as this file is only required
for dev builds and should not be included
- Correct default region
- Ticket #BL-11943
